### PR TITLE
Add Webhook API key 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Inside functions folder;
 `ngrok http 7001` to setup a tunnel to local firebase emulator.
 
 Set TG webhook URL e.g.;
-- `curl -F "url=https://<NGROK-URL>.ngrok.io/<firebase-url>/handleUpdate" https://api.telegram.org/<botID>:<TOKEN>/setWebhook`
+- `curl -F "url=https://<NGROK-URL>.ngrok.io/<firebase-url>/telegram/RANDOM-API-KEY" https://api.telegram.org/<botID>:<TOKEN>/setWebhook`
+
+The `RANDOM-API-KEY` is an API key that you choose yourself and set on the Firebase Config (see below).
 
 ## Sync Firebase Config
 Inside functions folder;
@@ -17,6 +19,7 @@ Inside functions folder;
 - `firebase functions:config:set telegram.bot_token="<botID>:<TOKEN>"`
 - `firebase functions:config:set env.production=true`
 - `firebase functions:config:set env.database_url="https://<FB_RTDB_URL>.rtdb.firebaseio.com/"`
+- `firebase functions:config:set env.webhook_api_key="RANDOM-API-KEY"`
 - `firebase functions:config:set dag_network.id="ceres"`
 - `firebase functions:config:set dag_network.be_url="https://api-be.exchanges.constellationnetwork.io"`
 - `firebase functions:config:set dag_network.lb_url="http://lb.exchanges.constellationnetwork.io:9000"`
@@ -27,4 +30,4 @@ Just run `firebase deploy` inside this folder, you'll need to have Firebase setu
 ## Change Telegram Bot;
 - Run `firebase functions:config:set telegram.bot_token="<botID>:<TOKEN>"`
 - And of course set the Webhook URL for that bot;
-- `curl -F "url=https://<FB_PROJECT>.cloudfunctions.net/handleUpdate" https://api.telegram.org/<botID>:<TOKEN>/setWebhook`
+- `curl -F "url=https://<FB_PROJECT>.cloudfunctions.net/telegram/RANDOM-API-KEY" https://api.telegram.org/<botID>:<TOKEN>/setWebhook`

--- a/functions/.runtimeconfig.json.example
+++ b/functions/.runtimeconfig.json.example
@@ -1,13 +1,13 @@
 {
     "env": {
         "production": false,
-        "databaseURL": "",
-        "webhookAPIKey": "some-secure-string"
+        "database_url": "",
+        "webhook_api_key": "some-secure-string"
     },
     "dag_network": {
         "id": "ceres",
-        "beUrl": "https://api-be.exchanges.constellationnetwork.io",
-        "lbUrl": "http://lb.exchanges.constellationnetwork.io:9000"
+        "be_url": "https://api-be.exchanges.constellationnetwork.io",
+        "lb_url": "http://lb.exchanges.constellationnetwork.io:9000"
     },
     "telegram": {
         "bot_token": "<bot_id>:<bot_token>"

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,7 +10,7 @@ Database.getInstance();
 const webhook = new Webhook();
 
 // Get TG Webhook API key from ENV.
-const WEBHOOK_API_KEY = config().env.webhookAPIKey;
+const WEBHOOK_API_KEY = config().env.webhook_api_key;
 
 // Ensure user_id / username combination is always updated in `usernames` table,
 // when usernames change for TG userIDs.


### PR DESCRIPTION
I've added a webhook API key that can be set in the Firebase ENV. The function will check the key when TG makes calls to the webhook, to make sure we're getting the right calls.

I'm also changing the `handleUpdate` function name to `telegram`, for now, they'll both be there since we'll need to migrate the bot and prevent downtime.

After this change, the webhook URL will be `https://<fb-project>.cloudfunctions.net/telegram/RANDOM-API-KEY` instead of `https://<fb-project>.cloudfunctions.net/handleUpdate`.